### PR TITLE
Support for passing lambdas to `fires` as :actor, :secondary_subject and :subject

### DIFF
--- a/lib/timeline_fu/fires.rb
+++ b/lib/timeline_fu/fires.rb
@@ -19,11 +19,14 @@ module TimelineFu
         method_name = :"fire_#{event_type}_after_#{opts[:on]}"
         define_method(method_name) do
           create_options = [:actor, :subject, :secondary_subject].inject({}) do |memo, sym|
-            case opts[sym]
-            when :self
-              memo[sym] = self
-            else
-              memo[sym] = send(opts[sym]) if opts[sym]
+            if opts[sym]
+              if opts[sym].respond_to?(:call)
+                memo[sym] = opts[sym].call(self)
+              elsif opts[sym] == :self
+                memo[sym] = self
+              else
+                memo[sym] = send(opts[sym])
+              end
             end
             memo
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ class Person < ActiveRecord::Base
   attr_accessor :new_watcher, :fire
   
   fires :follow_created,  :on     => :update, 
-                          :actor  => :new_watcher, 
+                          :actor  => lambda { |person| person.new_watcher }, 
                           :if     => lambda { |person| !person.new_watcher.nil? }
   fires :person_updated,  :on     => :update,
                           :if     => :fire?


### PR DESCRIPTION
I used to do the following (not very elegant):

```
fires :new_employee, :on => :create, :actor => :actor_for_timeline
# This method is only defined to get TimelineFu
# to set User.current as the TimelineEvent's actor:
def actor_for_timeline
  User.current
end
```

With my patch, the above code can be simplified:

```
fires :new_employee, :on => :create, :actor => lambda { User.current }
```

Different question:
One of the tests has been on my machine - even before I changed anything. The method `has_entry` is missing, which seems to be related to mocking. What gems do I need to install to get this test to pass?

```
1) Error:
test_should_set_secondary_subject_to_self_when_requested(FiresTest):
NoMethodError: undefined method `has_entry' for #<FiresTest:0x102088b00>
.../timeline_fu/test/fires_test.rb:67:in `test_should_set_secondary_subject_to_self_when_requested'
```
