### PR TITLE
Various fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg
 .DS_Store
+*.rbc

--- a/generators/timeline_fu/templates/migration.rb
+++ b/generators/timeline_fu/templates/migration.rb
@@ -5,11 +5,13 @@ class CreateTimelineEvents < ActiveRecord::Migration
       t.integer               :subject_id,    :actor_id,    :secondary_subject_id
       t.timestamps
     end
+
+    add_index :timeline_events, [:subject_id , :subject_type]
+    add_index :timeline_events, [:actor_id , :actor_type]
+    add_index :timeline_events, [:secondary_subject_id , :secondary_subject_type], :name => 'secondary_subject_timeline_events'
   end
- 
+
   def self.down
     drop_table :timeline_events
   end
 end
- 
-

--- a/generators/timeline_fu/templates/migration.rb
+++ b/generators/timeline_fu/templates/migration.rb
@@ -6,10 +6,10 @@ class CreateTimelineEvents < ActiveRecord::Migration
       t.timestamps
     end
   end
- 
+
   def self.down
     drop_table :timeline_events
   end
 end
- 
+
 

--- a/generators/timeline_fu/templates/migration.rb
+++ b/generators/timeline_fu/templates/migration.rb
@@ -1,11 +1,13 @@
 class CreateTimelineEvents < ActiveRecord::Migration
   def self.up
     create_table :timeline_events do |t|
+      t.references :account
       t.string   :event_type, :subject_type,  :actor_type,  :secondary_subject_type
       t.integer               :subject_id,    :actor_id,    :secondary_subject_id
       t.timestamps
     end
 
+    add_index :timeline_events, :account_id
     add_index :timeline_events, [:subject_id , :subject_type]
     add_index :timeline_events, [:actor_id , :actor_type]
     add_index :timeline_events, [:secondary_subject_id , :secondary_subject_type], :name => 'secondary_subject_timeline_events'

--- a/generators/timeline_fu/templates/model.rb
+++ b/generators/timeline_fu/templates/model.rb
@@ -1,4 +1,5 @@
 class TimelineEvent < ActiveRecord::Base
+  belongs_to :account
   belongs_to :actor,              :polymorphic => true
   belongs_to :subject,            :polymorphic => true
   belongs_to :secondary_subject,  :polymorphic => true

--- a/lib/timeline_fu/fires.rb
+++ b/lib/timeline_fu/fires.rb
@@ -18,7 +18,7 @@ module TimelineFu
 
         method_name = :"fire_#{event_type}_after_#{opts[:on]}"
         define_method(method_name) do
-          create_options = [:actor, :subject, :secondary_subject].inject({}) do |memo, sym|
+          create_options = [:account, :actor, :subject, :secondary_subject].inject({}) do |memo, sym|
             if opts[sym]
               if opts[sym].respond_to?(:call)
                 memo[sym] = opts[sym].call(self)

--- a/test/fires_test.rb
+++ b/test/fires_test.rb
@@ -63,11 +63,17 @@ class FiresTest < Test::Unit::TestCase
   end
 
   def test_should_set_secondary_subject_to_self_when_requested
-    @list = List.new(hash_for_list(:author => @james));
-    TimelineEvent.stubs(:create!).with(has_entry(:event_type, "list_created_or_updated"))
+    @list = List.new(hash_for_list(:author => @james))
+    TimelineEvent.expects(:create!).with(:actor             => @james,
+                                         :subject           => @list,
+                                         :secondary_subject => @list,
+                                         :event_type        => 'list_created_or_updated')
     @list.save
     @comment = Comment.new(:body => 'cool list!', :author => @mat, :list => @list)
-    TimelineEvent.stubs(:create!).with(has_entry(:event_type, "comment_created"))
+    TimelineEvent.expects(:create!).with(:actor             => @mat,
+                                         :subject           => @comment,
+                                         :secondary_subject => @comment,
+                                         :event_type        => 'comment_created')
     @comment.save
     TimelineEvent.expects(:create!).with(:actor             => @mat, 
                                          :subject           => @list, 

--- a/test/fires_test.rb
+++ b/test/fires_test.rb
@@ -2,15 +2,16 @@ require File.dirname(__FILE__)+'/test_helper'
 
 class FiresTest < Test::Unit::TestCase
   def setup
-    @james = create_person(:email => 'james@giraffesoft.ca')
-    @mat   = create_person(:email => 'mat@giraffesoft.ca')
+    @account = create_account
+    @james = create_person(:account => @account, :email => 'james@giraffesoft.ca')
+    @mat   = create_person(:account => @account, :email => 'mat@giraffesoft.ca')
   end
   
   def test_should_fire_the_appropriate_callback
     @list = List.new(hash_for_list(:author => @james));
-    TimelineEvent.expects(:create!).with(:actor => @james, :subject => @list, :event_type => 'list_created_or_updated')
+    TimelineEvent.expects(:create!).with(:account => @account, :actor => @james, :subject => @list, :event_type => 'list_created_or_updated')
     @list.save
-    TimelineEvent.expects(:create!).with(:actor => @mat, :subject => @list, :event_type => 'list_created_or_updated')
+    TimelineEvent.expects(:create!).with(:account => @account, :actor => @mat, :subject => @list, :event_type => 'list_created_or_updated')
     @list.author = @mat
     @list.save
   end
@@ -20,7 +21,8 @@ class FiresTest < Test::Unit::TestCase
     TimelineEvent.stubs(:create!)
     @list.save
     @comment = Comment.new(:body => 'cool list!', :author => @mat, :list => @list)
-    TimelineEvent.expects(:create!).with(:actor             => @mat, 
+    TimelineEvent.expects(:create!).with(:account           => @account,
+                                         :actor             => @mat, 
                                          :subject           => @comment, 
                                          :secondary_subject => @list, 
                                          :event_type        => 'comment_created')
@@ -39,7 +41,7 @@ class FiresTest < Test::Unit::TestCase
   end
 
   def test_should_only_fire_if_the_condition_evaluates_to_true
-    TimelineEvent.expects(:create!).with(:actor => @mat, :subject => @james, :event_type => 'follow_created')
+    TimelineEvent.expects(:create!).with(:account => @account, :actor => @mat, :subject => @james, :event_type => 'follow_created')
     @james.new_watcher = @mat
     @james.save
   end
@@ -52,7 +54,7 @@ class FiresTest < Test::Unit::TestCase
   
   def test_should_fire_event_with_symbol_based_if_condition_that_is_true
     @james.fire = true
-    TimelineEvent.expects(:create!).with(:subject => @james, :event_type => 'person_updated')
+    TimelineEvent.expects(:create!).with(:account => @account, :subject => @james, :event_type => 'person_updated')
     @james.save
   end
   
@@ -64,18 +66,21 @@ class FiresTest < Test::Unit::TestCase
 
   def test_should_set_secondary_subject_to_self_when_requested
     @list = List.new(hash_for_list(:author => @james))
-    TimelineEvent.expects(:create!).with(:actor             => @james,
+    TimelineEvent.expects(:create!).with(:account           => @account,
+                                         :actor             => @james,
                                          :subject           => @list,
                                          :secondary_subject => @list,
                                          :event_type        => 'list_created_or_updated')
     @list.save
     @comment = Comment.new(:body => 'cool list!', :author => @mat, :list => @list)
-    TimelineEvent.expects(:create!).with(:actor             => @mat,
+    TimelineEvent.expects(:create!).with(:account           => @account,
+                                         :actor             => @mat,
                                          :subject           => @comment,
                                          :secondary_subject => @comment,
                                          :event_type        => 'comment_created')
     @comment.save
-    TimelineEvent.expects(:create!).with(:actor             => @mat, 
+    TimelineEvent.expects(:create!).with(:account           => @account,
+                                         :actor             => @mat, 
                                          :subject           => @list, 
                                          :secondary_subject => @comment, 
                                          :event_type        => 'comment_deleted')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'activerecord'
+require 'active_record'
 require 'mocha'
 require 'test/unit'
 require 'logger'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,13 @@ ActiveRecord::Base.logger = Logger.new(STDERR)
 ActiveRecord::Base.logger.level = Logger::WARN
 
 ActiveRecord::Schema.define(:version => 0) do
+  create_table :accounts do |t|
+    t.string :name, :default => ""
+    t.string :description, :default => ""
+  end
+
   create_table :people do |t|
+    t.references :account
     t.string  :email,    :default => ''
     t.string  :password, :default => ''
   end
@@ -29,9 +35,15 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 end
 
+class Account < ActiveRecord::Base
+  has_many :people
+end
+
 class Person < ActiveRecord::Base
   attr_accessor :new_watcher, :fire
-  
+
+  belongs_to :account
+
   fires :follow_created,  :on     => :update, 
                           :actor  => lambda { |person| person.new_watcher }, 
                           :if     => lambda { |person| !person.new_watcher.nil? }
@@ -47,7 +59,8 @@ class List < ActiveRecord::Base
   belongs_to :author, :class_name => "Person"
   has_many :comments
   
-  fires :list_created_or_updated,  :actor  => :author, 
+  fires :list_created_or_updated,  :account => Proc.new { |list| list.author.account_id },
+                                   :actor  => :author, 
                                    :on     => [:create, :update]
 end
 
@@ -55,10 +68,12 @@ class Comment < ActiveRecord::Base
   belongs_to :list
   belongs_to :author, :class_name => "Person"
 
-  fires :comment_created, :actor   => :author,
+  fires :comment_created, :account => Proc.new { |comment| comment.list.author.account_id },
+                          :actor   => :author,
                           :on      => :create,
                           :secondary_subject => :list
-  fires :comment_deleted, :actor   => :author,
+  fires :comment_deleted, :account => Proc.new { |comment| comment.list.author.account_id },
+                          :actor   => :author,
                           :on      => :destroy,
                           :subject => :list,
                           :secondary_subject => :self
@@ -68,6 +83,14 @@ TimelineEvent = Class.new
 
 class Test::Unit::TestCase
   protected
+    def hash_for_account(opts = {})
+      {:name => "fantasy inc.", :description => "rails shop"}.merge(opts)
+    end
+
+    def create_account(opts = {})
+      Account.create!(hash_for_account(opts))
+    end
+
     def hash_for_list(opts = {})
       {:title => 'whatever'}.merge(opts)
     end

--- a/timeline_fu.gemspec
+++ b/timeline_fu.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
      "test/test_helper.rb",
      "timeline_fu.gemspec"
   ]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/giraffesoft/timeline_fu}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
1. pulled from damireh: added indices to timeline_events migration
2. pulled from rohit: Remove extra whitespace from migration template
3. `.gititnore` all `*.rbc` files (generated by rubinius)
4. require active_record instead of activerecord in order to support 3.1 series or rails (maybe 3.0 series as well)
5. fix test. for some reason moch `has_entry` method is undefined on my system. replace `has_entry` with "full" expectations to fix the issue (same technique as in other tests). note: `has_entry` is supposed to be defined in `mocha`.
6. multitenancy support: add `belongs_to :account` to timeline event incl. support for passing `:account` to the fires macro. tests are up to date as well.

hope you like it! thanks!
