### PR TITLE
Allow additional attributes to pass to timeline event

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,6 +43,8 @@ The rest all fit neatly in an options hash.
 - :subject is automatically set to self, which is good most of the time.  You can however override it if you need to, using :subject.
 - :secondary_subject can let you specify something else that's related to the event. A comment to a blog post would be a good example.
 - :if => symbol or proc/lambda lets you put conditions on when a TimelineEvent is created. It's passed right to the after_xxx ActiveRecord event hook, so it's has the same behavior.
+- any other parameter is treated as TimelineEvent's attribute
+  - This is useful if you add a custom field to timeline_events table
 
 Here's another example:
 

--- a/lib/timeline_fu/fires.rb
+++ b/lib/timeline_fu/fires.rb
@@ -16,9 +16,12 @@ module TimelineFu
 
         opts[:subject] = :self unless opts.has_key?(:subject)
 
-        method_name = :"fire_#{event_type}_after_#{opts[:on]}"
+        on = opts.delete(:on)
+        _if = opts.delete(:if)
+
+        method_name = :"fire_#{event_type}_after_#{on}"
         define_method(method_name) do
-          create_options = [:actor, :subject, :secondary_subject].inject({}) do |memo, sym|
+          create_options = opts.keys.inject({}) do |memo, sym|
             case opts[sym]
             when :self
               memo[sym] = self
@@ -32,7 +35,7 @@ module TimelineFu
           TimelineEvent.create!(create_options)
         end
 
-        send(:"after_#{opts[:on]}", method_name, :if => opts[:if])
+        send(:"after_#{on}", method_name, :if => _if)
       end
     end
   end

--- a/test/fires_test.rb
+++ b/test/fires_test.rb
@@ -75,4 +75,11 @@ class FiresTest < Test::Unit::TestCase
                                          :event_type        => 'comment_deleted')
     @comment.destroy
   end
+
+  def test_should_set_additional_attributes_when_present
+    @site = Site.create(:name => 'foo.com')
+    @article = Article.new(:body => 'cool article!', :author => @james, :site => @site)
+    TimelineEvent.expects(:create!).with(:actor => @james, :subject => @article, :event_type => 'article_created', :site => @site)
+    @article.save
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,15 @@ ActiveRecord::Schema.define(:version => 0) do
     t.integer :list_id, :author_id
     t.string  :body
   end
+
+  create_table :sites do |t|
+    t.string  :name
+  end
+
+  create_table :articles do |t|
+    t.integer :site_id
+    t.string :body
+  end
 end
 
 class Person < ActiveRecord::Base
@@ -62,6 +71,18 @@ class Comment < ActiveRecord::Base
                           :on      => :destroy,
                           :subject => :list,
                           :secondary_subject => :self
+end
+
+class Site < ActiveRecord::Base
+end
+
+class Article < ActiveRecord::Base
+  belongs_to :author, :class_name => "Person"
+  belongs_to :site
+
+  fires :article_created, :actor => :author,
+                          :on    => :create,
+                          :site  => :site
 end
 
 TimelineEvent = Class.new


### PR DESCRIPTION
It would be nice to add additional attributes to timeline event. I attach a patch that allows it

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jamesgolick/timeline_fu/8)

<!-- Reviewable:end -->
