### PR TITLE
Description of the subject

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,6 +43,7 @@ The rest all fit neatly in an options hash.
 - :subject is automatically set to self, which is good most of the time.  You can however override it if you need to, using :subject.
 - :secondary_subject can let you specify something else that's related to the event. A comment to a blog post would be a good example.
 - :if => symbol or proc/lambda lets you put conditions on when a TimelineEvent is created. It's passed right to the after_xxx ActiveRecord event hook, so it's has the same behavior.
+- :subject_description => Description of the subject (like subject.name). This is important for items deleted. When listing the events somewhere in your code and you should first check whether the subject is null (because it has been deleted) and if so, you should just print its description instead. 
 
 Here's another example:
 

--- a/generators/timeline_fu/templates/migration.rb
+++ b/generators/timeline_fu/templates/migration.rb
@@ -1,7 +1,7 @@
 class CreateTimelineEvents < ActiveRecord::Migration
   def self.up
     create_table :timeline_events do |t|
-      t.string   :event_type, :subject_type,  :actor_type,  :secondary_subject_type
+      t.string   :event_type, :subject_type,  :actor_type,  :secondary_subject_type, :subject_description
       t.integer               :subject_id,    :actor_id,    :secondary_subject_id
       t.timestamps
     end

--- a/lib/timeline_fu/fires.rb
+++ b/lib/timeline_fu/fires.rb
@@ -18,7 +18,7 @@ module TimelineFu
 
         method_name = :"fire_#{event_type}_after_#{opts[:on]}"
         define_method(method_name) do
-          create_options = [:actor, :subject, :secondary_subject].inject({}) do |memo, sym|
+          create_options = [:actor, :subject, :secondary_subject, :subject_description].inject({}) do |memo, sym|
             case opts[sym]
             when :self
               memo[sym] = self


### PR DESCRIPTION
I've just merge your current master branch with the feature added by [Bernat](https://github.com/bernat/timeline_fu) . From his description:

> > Little modification: Another field is added to the TimelineEvent table, the description of the subject. When the subject will be removed from the database, its description will remain in the event so the related past events can still be displayed and the deletion event can show the description instead of the subject itself (which is nil).
